### PR TITLE
correct typo

### DIFF
--- a/chapters/basic-datatypes.tex
+++ b/chapters/basic-datatypes.tex
@@ -105,7 +105,7 @@ Suggestion: the remainder of $x/2$ is always zero when $x$ is even.
 
 \section{Exercises with strings}
 
-Using the Python documentation on strings (\url{https://docs.python.org/3/library/string.html)}, solve the following exercises:
+Using the Python documentation on strings (\url{https://docs.python.org/3/library/string.html}), solve the following exercises:
 
 \begin{enumerate}
 


### PR DESCRIPTION
the url link adds a ')' to the end so does not resolve correctly. just cleaning it up.