### PR TITLE
Keys cannot be any type of objects

### DIFF
--- a/chapters/dictionaries.tex
+++ b/chapters/dictionaries.tex
@@ -34,7 +34,7 @@ Maria 12
 Gabriel 10
 \end{lstlisting}
 
-However, keys don't need to be necessarily strings and integers but can be any objects:
+However, keys don't need to be necessarily strings and integers but can be any [immutable](https://docs.python.org/3/tutorial/datastructures.html#dictionaries) objects:
 
 \begin{lstlisting}
 d = {


### PR DESCRIPTION
I am not sure if particular change is good, since it may be out of context, but find my argumentation below,

Official docs says: https://docs.python.org/3/tutorial/datastructures.html#dictionaries 

```
Unlike sequences, which are indexed by a range of numbers, dictionaries are indexed by keys, which can be any immutable type; strings and numbers can always be keys.
```

As far I understand that this is practical and basic introduction - there should be explained difference between immutable vs mutable types - especially with the dictionary keys case.