### PR TITLE
Corrected formula to match results

### DIFF
--- a/chapters/iterators.md
+++ b/chapters/iterators.md
@@ -4,7 +4,7 @@ As we saw previously, in Python we use the "for" loop to iterate over the conten
 
 ```Python
 >>> for value in [0, 1, 2, 3, 4, 5]:
-...     print(value)
+...     print(value*value)
 ...
 0
 1


### PR DESCRIPTION
>>> for value in [0, 1, 2, 3, 4, 5]:
...     print(value)

does not match the printed result:

0
1
4
9
16
25

So changed to

>>> for value in [0, 1, 2, 3, 4, 5]:
...     print(value*value)